### PR TITLE
Refactor menus to use PySide6 widgets

### DIFF
--- a/imagine_part3.py
+++ b/imagine_part3.py
@@ -1,7 +1,12 @@
     def _create_menus(self):
         """Set up the application menu bar and toolbar using Qt widgets."""
-        menubar = self.menuBar()
-        menubar.clear()
+        menubar = getattr(self, '_menubar', None)
+        if menubar is None:
+            menubar = QtWidgets.QMenuBar(self)
+            self.setMenuBar(menubar)
+            self._menubar = menubar
+        else:
+            menubar.clear()
 
         toolbar = getattr(self, '_main_toolbar', None)
         if toolbar is None:

--- a/imagine_part3.py
+++ b/imagine_part3.py
@@ -1,12 +1,8 @@
     def _create_menus(self):
         """Set up the application menu bar and toolbar using Qt widgets."""
-        menubar = getattr(self, '_menubar', None)
-        if menubar is None:
-            menubar = QtWidgets.QMenuBar(self)
-            self.setMenuBar(menubar)
-            self._menubar = menubar
-        else:
-            menubar.clear()
+        menubar = self.menuBar()
+        menubar.clear()
+        self._menubar = menubar
 
         toolbar = getattr(self, '_main_toolbar', None)
         if toolbar is None:


### PR DESCRIPTION
## Summary
- rebuild the ImagineApp menu bar using PySide6 QMenuBar/QMenu/QAction components and add a matching QToolBar for common commands
- update extension loading to populate the new Qt-based Extensions menu instead of relying on tk.Menu APIs

## Testing
- python -m compileall imagine_part3.py *(fails: file is a partial segment when compiled independently)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e8994320832ca381e58f2abeb66a