### PR TITLE
Disable native menu bar for ImagineApp

### DIFF
--- a/imagine_part3.py
+++ b/imagine_part3.py
@@ -2,6 +2,10 @@
         """Set up the application menu bar and toolbar using Qt widgets."""
         menubar = self.menuBar()
         menubar.clear()
+        try:
+            menubar.setNativeMenuBar(False)
+        except AttributeError:
+            pass
         self._menubar = menubar
 
         toolbar = getattr(self, '_main_toolbar', None)


### PR DESCRIPTION
## Summary
- disable the native menu bar when building ImagineApp menus so the Qt menubar stays attached to the window

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ef733cf4832cb9f7f0dfe3bf3d62